### PR TITLE
Update congress gem to use HTTPS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,8 @@ gem 'fog'
 
 gem "awesome_nested_set", ">= 2.0"
 
-# Open Gov APIs
-gem "congress"
+# Sunlight Foundation Congress API v3
+gem "congress", ">= 0.2.0"
 
 # jammit support
 gem "jammit"


### PR DESCRIPTION
The new version of the [congress gem](http://rubygems.org/gems/congress) ([source on github](https://github.com/codeforamerica/congress), released today, uses the Sunlight Congress API's HTTPS endpoint. It has some other improvements from the last 6 months, since its last release, such as building in geocoder support. But the HTTPS support is why I'm submitting this PR.

There aren't any changes in dependencies as part of this upgrade, and there shouldn't be any backwards compatibility issues.
