### PR TITLE
Specify sentry-raven version: 0.10.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,6 +128,9 @@ gem 'acts-as-taggable-on'
 
 gem 'simple_form'
 
+# Report errors to Sentry
+gem 'sentry-raven', "0.10.1"
+
 # Mail
 gem 'mechanize'
 gem 'formageddon', '~> 0.0.2', :git => 'git://github.com/sunlightlabs/formageddon.git', :branch => "beta"
@@ -152,7 +155,6 @@ end
 
 group :production, :staging do
   gem 'unicorn'
-  gem 'sentry-raven' #, :git => "git://github.com/getsentry/raven-ruby.git"
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,9 +445,8 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
-    sentry-raven (0.9.4)
+    sentry-raven (0.10.1)
       faraday (>= 0.7.6)
-      hashie (>= 1.1.0)
       uuidtools
     settingslogic (2.0.9)
     sexmachine (0.1.0)
@@ -606,7 +605,7 @@ DEPENDENCIES
   ruby-openid
   sass-rails (>= 4.0.0)
   selenium-webdriver
-  sentry-raven
+  sentry-raven (= 0.10.1)
   settingslogic
   sexmachine
   sidekiq


### PR DESCRIPTION
So anyone working on this is going to want to be sure that they **unset sentry_dsn:** in their local version of api_keys.yml (or, alternatively, put in your desired sentry_dsn into api_keys.yml). Basically, we don't want to send local errors to a Sentry account that's supposed to be monitoring a non-local environment. 
