### PR TITLE
Only send notification outbounds in production

### DIFF
--- a/app/models/notification_outbound.rb
+++ b/app/models/notification_outbound.rb
@@ -58,8 +58,10 @@ class NotificationOutbound < OpenCongressModel
 
   # TODO: implement the delivery cases
   def send_notification
-    self.send("send_#{outbound_type}".to_sym) rescue logger.error "Outbound type '#{outbound_type}' not found."
-    self.update_attributes!({sent: 1})
+    if Rails.env == "production"
+      self.send("send_#{outbound_type}".to_sym) rescue logger.error "Outbound type '#{outbound_type}' not found."
+      self.update_attributes!({sent: 1})
+    end
   end
 
   private


### PR DESCRIPTION
If we implement notifications outside of ActionMailer, this ought to catch unwanted ones from passing through on dev/staging.
