### PR TITLE
Don't send notification emails if there are too many incoming communicat...

### DIFF
--- a/app/jobs/get_formageddon_replies_job.rb
+++ b/app/jobs/get_formageddon_replies_job.rb
@@ -18,8 +18,15 @@ module GetFormageddonRepliesJob
             (letter.subject =~ /E\-News/).nil? &&
             (letter.subject =~ /Newsletter/).nil?)
         notifications_sent += 1
-        Rails.logger.info "Sending an email notification to: #{cclft.contact_congress_letter.user.email}"
-        ContactCongressMailer.reply_received_email(cclft.contact_congress_letter, letter.formageddon_thread).deliver
+        begin
+          incoming_letters_on_chain = letter.formageddon_thread.formageddon_letters.select{|d| d.direction = "TO_SENDER"}.count
+        rescue
+          incoming_letters_on_chain = 0
+        end
+        if incoming_letters_on_chain < 4 #assume address has been subscribed to newsletter if > 3
+          Rails.logger.info "Sending an email notification to: #{cclft.contact_congress_letter.user.email}"
+          ContactCongressMailer.reply_received_email(cclft.contact_congress_letter, letter.formageddon_thread).deliver
+        end
       end
     end
     puts "#{emails_received} emails, #{notifications_sent} notifications"


### PR DESCRIPTION
...ions

Formageddon email addresses get subscribed to members' mailing lists, which
leads to their spamming users that contact them via formageddon. We will still
accept and archive these communications, but won't notify users if there are
more than 3 communications from an office on a particular formageddon_thread.
