### PR TITLE
Person scopes and basic filtering infrastructure

### DIFF
--- a/app/concerns/filterable.rb
+++ b/app/concerns/filterable.rb
@@ -1,0 +1,13 @@
+module Filterable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def filter(filtering_params)
+      results = self.where(nil)
+      filtering_params.each do |key, value|
+        results = results.public_send(key, value) if value.present?
+      end
+      results
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -572,6 +572,16 @@ class ApplicationController < ActionController::Base
     @meta_tags_for_search.merge!(options)
   end
 
+  def filtering_defaults
+    model = controller_name.classify.constantize
+    model.filterable_fields[:basic].reject{ |k,v| v.nil? }
+  end
+
+  def filtering_params(filter_defaults=filtering_defaults)
+    model = controller_name.classify.constantize
+    filter_defaults.merge(params).slice(*model.filterable_fields[:basic].keys)
+  end
+
   # Set instance variable for page title, defaulting to "OpenCongress"
   # This instance variable is rendered in the main application layout.
   #

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -11,7 +11,7 @@ class PeopleController < ApplicationController
   skip_before_filter :protect_from_forgery, :only => :zipcodelookup
 
   def index
-    @page_title = 'Senators and Representatives'
+    @people = Person.filter(filtering_params(filtering_defaults))
   end
 
   ##
@@ -687,7 +687,6 @@ class PeopleController < ApplicationController
 
   end
 
-
   def can_text
     if !(logged_in? && current_user.user_role.can_manage_text)
       redirect_to admin_url
@@ -707,6 +706,12 @@ class PeopleController < ApplicationController
         end
       end
     end
+  end
+
+  def filtering_defaults
+    defaults = Person.filterable_fields[:basic].reject{ |k,v| v.nil? }
+    defaults.delete(:on_date) unless params[:for_congress].nil?
+    defaults
   end
 
 end

--- a/app/models/open_congress_model.rb
+++ b/app/models/open_congress_model.rb
@@ -87,6 +87,14 @@ class OpenCongressModel < ActiveRecord::Base
     super(stylize_serialization(ops))
   end
 
+  # Returns SQL-safe value for order
+  # 
+  # @params order [String] potentially malicious order string
+  # @return [String] "ASC" or "DESC"
+  def self.safe_order(order)
+    order.upcase[0] == "A" ? "ASC" : "DESC"
+  end
+
   private
 
   def stylize_serialization(ops)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -145,6 +145,7 @@ class Person < Bookmarkable
 
   scope :party, ->(party) { where("people.party LIKE ?", party.capitalize) }
   scope :in_state, ->(state) { where(state: state.upcase) }
+  scope :chamber, ->(chamber) { includes(:roles).where("roles.role_type = ?", chamber).references(:roles) }
 
   scope :state_order, ->(direction) { includes(:roles).order("roles.state #{self.safe_order(direction)}").references(:roles) }
   scope :alphabetical_order, ->(direction) { order("lastname #{self.safe_order(direction)}") }
@@ -1674,6 +1675,7 @@ class Person < Bookmarkable
         :party => nil,
         :congress => nil,
         :committee => nil,
+        :chamber => nil,
         :on_date => Date.today(),
         :state_order => nil,
         :alphabetical_order => nil,

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe PeopleController, type: :controller do
+  before(:each) do
+    #create 114th Congress
+    FactoryGirl.create(:nth_congress, {:number => Settings.default_congress})
+
+    # make sample legislators
+    ["Republican", "Democrat", "Independent"].each do |party|
+      #in office
+      [:representative, :senator].each do |chamber|
+        FactoryGirl.create(chamber, {
+            :party => party,
+            :state => "CO"
+          })
+      end
+      # retired 
+      FactoryGirl.create(:retired, {
+        :firstname => "retiredperson",
+        :party => party
+      })
+    end
+  end
+  describe 'GET #index' do
+    context 'when user supplies no filtering params' do
+      it 'should return _today\'s_ members of Congress (not the current congress)' do
+        retired = FactoryGirl.create(:left_mid_congress) #this person quit one day after the congress started
+
+        get :index
+        assigns(:people).each do |person|
+          expect(person.is_sitting?).to eq(true)
+        end
+      end
+    end
+    context 'when user filters by params[:for_congress]' do
+      it 'should return _all_ members of that congress, even if they retired' do
+        retired = FactoryGirl.create(:left_mid_congress) #this person quit one day after the congress started
+        get :index, {
+          :for_congress => 114
+        }
+        expect(assigns(:people).map(&:bioguideid)).to include(retired.bioguideid)
+      end
+    end
+    context 'when user filters via params[:committee]' do
+      it 'should only return members of the committee with that THOMAS id' do
+        committee_member = FactoryGirl.create(:representative)
+        committee = FactoryGirl.create(:committee, {:thomas_id => "WDGT"})
+        committee_member.committee_people << FactoryGirl.create(:committee_person, {session: Settings.default_congress, committee_id: committee.id })
+
+        get :index, {
+          :committee => "WDGT"
+        }
+
+        assigns(:people).each do |person|
+          expect(person.committees.map(&:thomas_id)).to include(committee.thomas_id)
+        end
+      end
+    end
+    context 'when user filters via params[:party]' do
+      it 'should only return current members of that party' do
+        get :index, {
+          :party => "Republican"
+        }
+        assigns(:people).each do |person|
+          expect(person.roles.first.party).to eq("Republican")
+          expect(person.roles.first.member_of_congress?(Settings.default_congress)).to eq(true)
+        end
+      end
+    end
+    context 'when user sorts via params[:party_order]' do
+      it 'should arrange people by party' do
+        get :index, {
+          :party_order => "DESC"
+        }
+        parties_sorted_in_controller = assigns(:people).map do |p|
+          p.roles.first.party
+        end
+        expect(parties_sorted_in_controller).to eq(parties_sorted_in_controller.sort.reverse)
+      end
+    end
+    context 'when user sorts via params[:state]' do
+      it 'should arrange people by state' do
+        get :index, {
+          :state_order => "DESC"
+        }
+        expect(assigns(:people).map(&:state)).to eq(assigns(:people).map(&:state).sort.reverse)
+      end
+    end
+    context 'when user sorts via params[:alphabetical_order]' do
+      it 'should arrange people by lastname' do
+        get :index, {
+          :alphabetical_order => "DESC"
+        }
+        expect(assigns(:people).map(&:lastname)).to eq(assigns(:people).map(&:lastname).sort.reverse)
+      end
+    end
+  end
+end

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -67,6 +67,17 @@ describe PeopleController, type: :controller do
         end
       end
     end
+    context 'when user filters via params[:chamber]' do
+      it "should only return current members of that chamber" do
+        get :index, {
+          :chamber => "rep"
+        }
+        assigns(:people).each do |person|
+          expect(person.roles.first.member_of_congress?).to eq(true)
+          expect(person.roles.first.role_type).to eq("rep")
+        end
+      end
+    end
     context 'when user sorts via params[:party_order]' do
       it 'should arrange people by party' do
         get :index, {

--- a/spec/factories/committee.rb
+++ b/spec/factories/committee.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :committee do 
+    name "Widgets Committee"
+    active true
+    thomas_id "WDGT"
+    chamber "house"
+  end
+end

--- a/spec/factories/committee_person.rb
+++ b/spec/factories/committee_person.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :committee_person do 
+    role "Chair"
+    session { Settings.default_congress }
+  end
+end

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -107,7 +107,7 @@ FactoryGirl.define do
           :party => left.party,
           :district => left.district,
           :startdate => NthCongress.start_datetime(Settings.default_congress),
-          :enddate => NthCongress.start_datetime(Settings.default_congress) + 1.year
+          :enddate => NthCongress.start_datetime(Settings.default_congress) + 1.day
         })
       end    
     end

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -48,6 +48,7 @@ FactoryGirl.define do
           :state => sen.state,
           :party => sen.party,
           :district => sen.district,
+          :role_type => "sen",
           :startdate => NthCongress.start_datetime(Settings.default_congress),
           :enddate => NthCongress.start_datetime(Settings.default_congress) + 6.years
         })
@@ -60,6 +61,7 @@ FactoryGirl.define do
           :state => sen.state,
           :party => sen.party,
           :district => sen.district,
+          :role_type => "sen",
           :startdate => NthCongress.start_datetime(Settings.default_congress) - 2.years,
           :enddate => NthCongress.start_datetime(Settings.default_congress) + 4.years
         })

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -98,6 +98,16 @@ describe Person do
       left_mid_congress = FactoryGirl.create(:left_mid_congress)
       @people = expect(Person.for_congress(Settings.default_congress).map(&:bioguideid)).to include(left_mid_congress.bioguideid)
     end
+
+    it "#chamber should return all members that have served in a chamber" do
+      retired = FactoryGirl.create(:retired)
+      senator = FactoryGirl.create(:senator)
+      rep = FactoryGirl.create(:representative)
+      all_house_ever = Person.chamber("rep").map(&:bioguideid)
+      expect(all_house_ever).to include(retired.bioguideid)
+      expect(all_house_ever).to include(rep.bioguideid)      
+      expect(all_house_ever).not_to include(senator.bioguideid) 
+    end
     
     it "#committee should return members that are on a specific committee" do
       ["CMT1", "CMT2"].each do |committee_id|

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -98,6 +98,63 @@ describe Person do
       left_mid_congress = FactoryGirl.create(:left_mid_congress)
       @people = expect(Person.for_congress(Settings.default_congress).map(&:bioguideid)).to include(left_mid_congress.bioguideid)
     end
+    
+    it "#committee should return members that are on a specific committee" do
+      ["CMT1", "CMT2"].each do |committee_id|
+        expect(Person.committee(committee_id)).to eq([])
+        committee_member = FactoryGirl.create(:representative)
+        committee = FactoryGirl.create(:committee, {:thomas_id => committee_id})
+        committee_member.committee_people << FactoryGirl.create(:committee_person, {session: Settings.default_congress, committee_id: committee.id })
+        members = Person.committee(committee_id)
+        expect(members.map(&:bioguideid)).to include(committee_member.bioguideid)
+        expect(members.length).to eq(1)
+      end
+    end
+
+    it "#state_order should sort members by state" do
+      FactoryGirl.create(:retired, {state: "TX"})
+      FactoryGirl.create(:retired, {state: "AZ"})      
+      sorted_people_states = Person.state_order("DESC").map do |p|
+        p.latest_role.state
+      end
+      current_elected_states_reversed = Person.all.map do |p|
+        p.latest_role.state
+      end.sort.reverse
+
+      expect(sorted_people_states).to eq(current_elected_states_reversed)
+    end
+
+    it "#alphabetical_order should sort members by last name" do
+      FactoryGirl.create(:representative, {:lastname => "Aardvark"})
+      FactoryGirl.create(:representative, {:lastname => "Zzip"})
+      sorted_people_lastnames = Person.alphabetical_order("DESC").map(&:lastname)
+      current_people_lastnames = Person.all.map(&:lastname).sort.reverse
+      expect(sorted_people_lastnames).to eq(current_people_lastnames)
+    end
+
+    it "#party_order should sort members by party" do
+      sorted_people_parties = Person.party_order("DESC").map do |p|
+        p.roles.first.party
+      end
+      current_people_parties_sorted = Person.all.map do |p|
+        p.roles.first.party
+      end.sort.reverse
+      expect(sorted_people_parties).to eq(current_people_parties_sorted)
+    end
+    it "#time_in_office_order should sort members by total years of service as a federal legislator, irrespective of their terms' consecutiveness" do    
+      pending("implementation")
+      senior_sen = FactoryGirl.create(:senator)
+      junior_sen = FactoryGirl.create(:senator)
+      (1..6).each do |i|
+        starting_congress = Settings.default_congress - (3*i) 
+        senior_sen.roles << FactoryGirl.create(:role, {
+          :role_type => "sen",
+          :startdate =>  NthCongress.start_datetime(starting_congress),
+          :enddate => NthCongress.end_datetime(starting_congress + 6)
+        })
+      end
+      expect(Person.time_in_office_order("desc")).to eq("some value")
+    end
   end
   describe "roll call votes" do
     it "should filter roll call votes by party" do
@@ -135,7 +192,7 @@ describe Person do
       end
     end
     describe "add_fec_id" do
-      it "should nondestructively add ids to existing array" do
+    it "should nondestructively add ids to existing array" do
         person = FactoryGirl.create(:representative)
         person.fec_ids = ["this_is_an_fec_id"]
         person.add_fec_id("this_too")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,15 +63,13 @@ RSpec.configure do |config|
   config.include ApplicationHelper
 
   config.before(:suite) do
-    DatabaseCleaner.clean_with :truncation
-  end
-
-  config.before(:each) do
     DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.start
+    DatabaseCleaner.clean_with(:truncation)
   end
 
-  config.after(:each) do
-    DatabaseCleaner.clean
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
   end
 end


### PR DESCRIPTION
This PR filters People based on [this model](http://www.justinweiss.com/blog/2014/02/17/search-and-filter-rails-models-without-bloating-your-controller/). Essentially, we whitelist scopes on a model, then apply them sequentially via the `filter` class method, which is added to a model through the `Filterable` module (`include Filterable`). It looks like this: `ModelName.filter(filtering_params)`

By default, a model's filterable fields and filtering defaults are defined in `ModelName.filterable_fields`. Conventionally, one calls `ModelName.filter(filtering_params)` in the controller, where `filtering_params` is a second controller method that applies the filtering defaults and whitelist.

`filtering_params` takes an optional hash of filtering defaults, which is useful if defaults must be transformed based on filtering parameters (e.g. in the PeopleController, there should be no default `on_date` if a `for_congress` param is passed in). If no hash is passed to `filtering_params`, non-`nil` values in `ModelName.filterable_fields` are regarded as defaults. E.G., in the following, `:parameter_with_default` defaults to "default_value", while `:parameter_without_default` will not be applied unless specified:
```
HashWithIndifferentAccess.new({
    :basic => {
        :parameter_with_default => "default_value",
        :parameter_without_default => nil
   }
})
```